### PR TITLE
feat: allow version input to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ branding:
   icon: 'octagon'
   color: 'gray-dark'
 inputs:
+  version:
+    description: Specify runn version
+    required: false
+    default: 'latest'
   command:
     description: run or list or loadt
     required: true
@@ -34,10 +38,10 @@ inputs:
   concurrent:
     description: Concurrent mode
     required: false
-    default: false    
+    default: false
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/k1low/runn:v0.75.1'
+  image: 'docker://ghcr.io/k1low/runn:${{ inputs.version }}'
   args:
     - ${{ inputs.command }}
     - ${{ inputs.path_pattern }}


### PR DESCRIPTION
Dear @k2tzumi,

I would like to extend my gratitude for developing such an invaluable tool; it has been instrumental in many of my projects.

I am reaching out to address a concern I've encountered while integrating this action into my project's Continuous Integration (CI). We frequently find ourselves waiting for the action to be updated with the latest version of the Runn image. It might be more efficient if the version could be specified via the action input, rather than being fixed.

I have proposed a potential solution and would appreciate your insights on its relevance. Additionally, I believe there may be further adjustments required in `.github/workflows`, given its role in version injection.

Thank you for your time and consideration.