### PR TITLE
Bump `actions/checkout` in example in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
           - 8080:80
     steps:
       -
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         uses: k2tzumi/runn-action@latest
         with:


### PR DESCRIPTION
Thank you for maintaining useful workflow.

As the title says, I found older version of `actions/checkout` is specified in readme and fixed.