### PR TITLE
Back merge manual release2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.99.5"
+    default: "v0.114.1"
   debug:
     description: Filter runbooks to be executed
     required: false


### PR DESCRIPTION
Attempted to re-cut the release from v0.100.0 to v0.114.1, but it was no use, so simply back-merge.
v0.115.0 will be released as a properly working version starting from v0.115.0.