### PR TITLE
Run integration tests when `pull_request` is triggered.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,6 +2,9 @@ name: Integration
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Hi @k2tzumi.

You can run tests with pull requests from outside.