### PR TITLE
feat: expand globstar

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,6 +113,7 @@ runs:
           LABEL_OPTIONS="--label \"${{ inputs.labels }}\""
         fi
         echo "label options: $LABEL_OPTIONS"
+        shopt -s globstar
         runn \
           ${{ inputs.command }} \
           ${{ inputs.path_pattern }} \


### PR DESCRIPTION
Support `path_pattern` containing globstar.

see: https://github.com/k2tzumi/runn-action/issues/44