### PR TITLE
Bump image version and update GitHub Actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
         ports:
           - 8080:80
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: 'Option test'
         uses: ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
             console.log(release)
             core.setOutput('url', release.data.html_url);
             return release.data.body
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Bump up image version
         id: bump-up-image-version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   release-job:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         id: get-release-note
         with:
           result-encoding: string
@@ -46,7 +46,7 @@ jobs:
           tag: '${{ github.event.inputs.version }} --force'
           tag_push: '--force'
       - name: Create Release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.122.2"
+    default: "v0.122.3"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.122.3"
+    default: "v0.123.0"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.128.3"
+    default: "v0.129.0"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.129.0"
+    default: "v0.129.1"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.128.2"
+    default: "v0.128.3"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.132.2"
+    default: "v0.133.0"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.129.5"
+    default: "v0.130.0"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.130.1"
+    default: "v0.130.2"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.125.0"
+    default: "v0.126.0"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.127.0"
+    default: "v0.127.1"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.129.2"
+    default: "v0.129.3"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.130.2"
+    default: "v0.131.0"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.127.2"
+    default: "v0.127.3"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.129.1"
+    default: "v0.129.2"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.127.3"
+    default: "v0.127.4"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.126.0"
+    default: "v0.126.1"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.128.1"
+    default: "v0.128.2"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.127.4"
+    default: "v0.128.0"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.123.1"
+    default: "v0.124.0"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.128.0"
+    default: "v0.128.1"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.123.0"
+    default: "v0.123.1"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.134.0"
+    default: "v0.135.0"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.132.1"
+    default: "v0.132.2"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.129.3"
+    default: "v0.129.4"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.124.1"
+    default: "v0.125.0"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.126.1"
+    default: "v0.127.0"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.132.0"
+    default: "v0.132.1"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.129.4"
+    default: "v0.129.5"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.133.0"
+    default: "v0.134.0"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.124.0"
+    default: "v0.124.1"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.127.1"
+    default: "v0.127.2"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.131.0"
+    default: "v0.132.0"
   debug:
     description: Filter runbooks to be executed
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   version:
     description: Specify runn version
     required: false
-    default: "v0.130.0"
+    default: "v0.130.1"
   debug:
     description: Filter runbooks to be executed
     required: false


### PR DESCRIPTION
Update the default version in the action configuration and bump the versions of dependencies in the GitHub Actions workflows. This includes upgrading `actions/checkout` from version 4 to 5 and `actions/github-script` from version 7 to 8.